### PR TITLE
Add managed-by label

### DIFF
--- a/tests/nodeComm_test.go
+++ b/tests/nodeComm_test.go
@@ -114,7 +114,10 @@ func createHostServiceSlices(cs *client.ClientSet) error {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: "default",
-				Labels:    map[string]string{"ingress": "", "kubernetes.io/service-name": s.ServiceName},
+				Labels: map[string]string{"ingress": "",
+					"kubernetes.io/service-name":             s.ServiceName,
+					"endpointslice.kubernetes.io/managed-by": "com-matrix-operator",
+				},
 			},
 			Ports: []discoveryv1.EndpointPort{
 				{


### PR DESCRIPTION
This commit adds the label managed-by to the
custom endpointslices, as recommended by
the offical doc:
https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/#management

The value "com-matrix-operator" is temporary.