### PR TITLE
Add the "optional" field

### DIFF
--- a/pkg/commatrix/commatrix.go
+++ b/pkg/commatrix/commatrix.go
@@ -25,17 +25,18 @@ type CommDetails struct {
 	Port        string `json:"port"`
 	NodeRole    string `json:"nodeRole"`
 	ServiceName string `json:"serviceName"`
+	Optional    string `json:"optional"`
 }
 
 func (cd CommDetails) String() string {
-	return fmt.Sprintf("%s\t\t\t%s\t\t\t%s\t\t\t%s\t\t\t%s", cd.Direction, cd.NodeRole, cd.Protocol, cd.Port, cd.ServiceName)
+	return fmt.Sprintf("%s\t\t\t%s\t\t\t%s\t\t\t%s\t\t\t%s\t\t\t%s", cd.Direction, cd.NodeRole, cd.Protocol, cd.Port, cd.ServiceName, cd.Optional)
 }
 
 func (m CommMatrix) PrintMat() {
 	w := new(tabwriter.Writer)
-	w.Init(os.Stdout, 8, 8, 0, '\t', 0)
+	w.Init(os.Stdout, 12, 12, 0, '\t', 0)
 	defer w.Flush()
-	fmt.Fprintf(w, " %s\t\t%s\t\t%s\t\t%s\t\t%s\n", "DIRECTION", "NODE-ROLE", "PROTOCOL", "PORT", "SERVICE")
+	fmt.Fprintf(w, " %s\t\t\t%s\t\t\t%s\t\t\t%s\t\t\t%s\t\t\t%s\n", "DIRECTION", "NODE-ROLE", "PROTOCOL", "PORT", "SERVICE", "OPTIONAL")
 
 	for i, cd := range m.Matrix {
 		fmt.Fprintf(w, "%d. %s\n", i+1, cd)
@@ -56,6 +57,10 @@ func CreateCommMatrix(cs *client.ClientSet, slices []discoveryv1.EndpointSlice) 
 	res := make([]CommDetails, 0)
 
 	for _, slice := range slices {
+		var optional string
+		if _, ok := slice.Labels["optional"]; ok {
+			optional = "true"
+		}
 		ports := make([]string, 0)
 		protocols := make([]string, 0)
 		for _, p := range slice.Ports {
@@ -70,6 +75,7 @@ func CreateCommMatrix(cs *client.ClientSet, slices []discoveryv1.EndpointSlice) 
 				Port:        strings.Join(ports, ","),
 				NodeRole:    nodesRoles[*endpoint.NodeName],
 				ServiceName: services,
+				Optional:    optional,
 			}
 			res = append(res, *commDetails)
 		}

--- a/tests/customEndpointSlices.json
+++ b/tests/customEndpointSlices.json
@@ -3,7 +3,8 @@
         "protocol":    "TCP",
         "port":        "43573",
         "nodeRole":    "worker",
-        "serviceName": "rpc.statd"
+        "serviceName": "rpc.statd",
+        "optional": "true"
     },
     {
         "protocol":    "TCP",
@@ -39,13 +40,15 @@
         "protocol":    "TCP",
         "port":        "22",
         "nodeRole":    "worker",
-        "serviceName": "sshd"
+        "serviceName": "sshd",
+        "optional": "true"
     },
     {
         "protocol":    "TCP",
         "port":        "111",
         "nodeRole":    "worker",
-        "serviceName": "rpcbind"
+        "serviceName": "rpcbind",
+        "optional": "true"
     },
     {
         "protocol":    "TCP",
@@ -57,7 +60,8 @@
         "protocol":    "TCP",
         "port":        "53249",
         "nodeRole":    "worker",
-        "serviceName": "rpc.statd"
+        "serviceName": "rpc.statd",
+        "optional": "true"
     },
     {
         "protocol":    "TCP",
@@ -117,13 +121,15 @@
         "protocol":    "TCP",
         "port":        "45559",
         "nodeRole":    "master",
-        "serviceName": "rpc.statd"
+        "serviceName": "rpc.statd",
+        "optional": "true"
     },
     {
         "protocol":    "TCP",
         "port":        "111",
         "nodeRole":    "master",
-        "serviceName": "rpcbind"
+        "serviceName": "rpcbind",
+        "optional": "true"
     },
     {
         "protocol":    "TCP",
@@ -135,7 +141,8 @@
         "protocol":    "TCP",
         "port":        "22",
         "nodeRole":    "master",
-        "serviceName": "sshd"
+        "serviceName": "sshd",
+        "optional": "true"
     },
     {
         "protocol":    "TCP",

--- a/tests/nodeComm_test.go
+++ b/tests/nodeComm_test.go
@@ -133,6 +133,10 @@ func createHostServiceSlices(cs *client.ClientSet) error {
 			},
 			AddressType: "IPv4",
 		}
+		if s.Optional == "true" {
+			endpointSlice.Labels["optional"] = "true"
+		}
+
 		_, err = cs.EndpointSlices("default").Create(context.TODO(), &endpointSlice, metav1.CreateOptions{})
 		if err != nil && !errors.IsAlreadyExists(err) {
 			return err


### PR DESCRIPTION
This commit add a new field "optional" to the
com-matrix entry, and will be set to true
for not-required ports like rpc, and sshd.