### PR TITLE
Refactor endpointslices to use generic client

### DIFF
--- a/e2etest/nodeComm_test.go
+++ b/e2etest/nodeComm_test.go
@@ -70,9 +70,7 @@ var _ = Describe("Comm Matrix", func() {
 			printComMat(clusterComMat)
 			outfile.Close()
 
-			var allNamespaces string
-
-			epSliceQuery, err := endpointslices.NewQuery(cs, allNamespaces)
+			epSliceQuery, err := endpointslices.NewQuery(cs)
 			Expect(err).ToNot(HaveOccurred())
 
 			ingerssSlices := epSliceQuery.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
 github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
+github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=

--- a/pkg/endpointslices/endpointslices_test.go
+++ b/pkg/endpointslices/endpointslices_test.go
@@ -1,0 +1,12 @@
+package endpointslices
+
+import (
+	"testing"
+)
+
+func TestNewQueryNilClient(t *testing.T) {
+	_, err := NewQuery(nil)
+	if err == nil {
+		t.Fatalf("expected error for empty client")
+	}
+}

--- a/pkg/fakeclient/fakeclient.go
+++ b/pkg/fakeclient/fakeclient.go
@@ -1,0 +1,53 @@
+package fakeclient
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var scheme *runtime.Scheme
+
+type ClusterResources struct {
+	Pods     []corev1.Pod
+	EpSlices []discoveryv1.EndpointSlice
+	Services []corev1.Service
+}
+
+func New(initObjects []client.Object) (client.Client, error) {
+	scheme := runtime.NewScheme()
+
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("corev1: add to scheme failed: %v", err)
+	}
+
+	if err := discoveryv1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("discoveryv1: add to scheme failed: %v", err)
+	}
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(initObjects...).
+		Build(), nil
+}
+
+func ObjectsFromResources(r ClusterResources) []client.Object {
+	objects := make([]client.Object, 0)
+	for _, pod := range r.Pods {
+		objects = append(objects, pod.DeepCopy())
+	}
+
+	for _, epSlice := range r.EpSlices {
+		objects = append(objects, epSlice.DeepCopy())
+	}
+
+	for _, service := range r.Services {
+		objects = append(objects, service.DeepCopy())
+	}
+
+	return objects
+}


### PR DESCRIPTION
In order to write unit tests for the endpointslices package we change it's interface to use a generic controller-runtime Client, and add a `fakeclient` package and a simple unit test.